### PR TITLE
fix: show map editor on launch

### DIFF
--- a/Intersect.Editor/Forms/frmMain.cs
+++ b/Intersect.Editor/Forms/frmMain.cs
@@ -88,19 +88,16 @@ namespace Intersect.Editor.Forms
         public FrmMain()
         {
             InitializeComponent();
-            Icon = System.Drawing.Icon.ExtractAssociatedIcon(System.Reflection.Assembly.GetExecutingAssembly().Location);
-
+            Icon = Icon.ExtractAssociatedIcon(System.Reflection.Assembly.GetExecutingAssembly().Location);
             dockLeft.Theme = new VS2015DarkTheme();
             Globals.MapListWindow = new FrmMapList();
-            Globals.MapListWindow.Show(dockLeft, DockState.DockRight);
             Globals.MapLayersWindow = new FrmMapLayers();
-            Globals.MapLayersWindow.Show(dockLeft, DockState.DockLeft);
-
-            Globals.MapEditorWindow = new FrmMapEditor();
-            Globals.MapEditorWindow.Show(dockLeft, DockState.Document);
-
             Globals.MapGridWindowNew = new FrmMapGrid();
+            Globals.MapEditorWindow = new FrmMapEditor();
+            Globals.MapListWindow.Show(dockLeft, DockState.DockRight);
+            Globals.MapLayersWindow.Show(dockLeft, DockState.DockLeft);
             Globals.MapGridWindowNew.Show(dockLeft, DockState.Document);
+            Globals.MapEditorWindow.Show(dockLeft, DockState.Document);
         }
 
         [System.Runtime.InteropServices.DllImport("user32.dll")]


### PR DESCRIPTION
(NET7 Branch)

After upgrading to .NET7, The MapGrid window shows up selected instead of the MapEditor when starting the editor. Seeing the code, this is what actually makes sense, no idea why it wasn't behaving like this before but the expected behavior is to have the MapEditor to show over when starting the editor, thus:
this commit sets the MapEditor to be shown by the end, giving us back the expected results.