### PR TITLE
Update: NuGet Packages (Core)

### DIFF
--- a/Intersect (Core)/Intersect.Core.csproj
+++ b/Intersect (Core)/Intersect.Core.csproj
@@ -62,8 +62,8 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.3.5" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="MessagePack" Version="2.4.59" />
-    <PackageReference Include="MessagePackAnalyzer" Version="2.4.59">
+    <PackageReference Include="MessagePack" Version="2.5.94" />
+    <PackageReference Include="MessagePackAnalyzer" Version="2.5.94">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -99,7 +99,7 @@
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.1" />
     <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
-    <PackageReference Include="System.IO.Abstractions" Version="19.2.1" />
+    <PackageReference Include="System.IO.Abstractions" Version="19.2.4" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />


### PR DESCRIPTION
- MessagePack: 2.4.59 -> 2.5.94
- MessagePackAnalyzer: 2.4.59 -> 2.5.94
- System.IO.Abstractions: 19.2.1 -> 19.2.4